### PR TITLE
Add license

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,6 @@ This plugin displays visual status by driving an onboard Neopixel on the SLB Bla
 
 Color states:
 No connection:orange(TBD), Idle:white, Cycle/Running:green, Jogging:green, Hold:yellow,  Door:yellow, Homing:blue, Check:blue, Alarm:red, E-stop:red, Sleep:gray, Tool Change:purple
+
+# License
+This code has been created within the context of Open Hardware and is licensed under the "CERN-OHL-S v2". Please read more about this in the LICENSE file. You could redistribute and modify this source and make products using it under the terms of the CERN-OHL-S v2. This means stuff like licensing your changes reciprocally, giving attribution to us, and releasing hardware that this code runs on as CERN-OHL-S v2 too. Note that this LICENSE applies on all coding work done in prior commits to-date, and is now being released in good faith that no action will be taken to pursue past work in order to duplicate the work we've put in without having to abide by the License that's now being applied at its first public release.

--- a/rgb.c
+++ b/rgb.c
@@ -15,20 +15,26 @@
   Code heavily modified for use with Sienci SuperLongBoard and NEOPIXELS.
   Copyright (c) 2023 Sienci Labs
 
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+  This file is part of the SuperLongBoard family of products.
+  
+   This source describes Open Hardware and is licensed under the "CERN-OHL-S v2"
 
-  This RGB control plugin is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with GrblHAL.  If not, see <http://www.gnu.org/licenses/>.
-
-  Copyright reserved by the author.
+   You may redistribute and modify this source and make products using
+   it under the terms of the CERN-OHL-S v2 (https://ohwr.org/cern_ohl_s_v2.t). 
+   This source is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
+   INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A 
+   PARTICULAR PURPOSE. Please see the CERN-OHL-S v2 for applicable conditions.
+   
+   As per CERN-OHL-S v2 section 4, should You produce hardware based on this 
+   source, You must maintain the Source Location clearly visible on the external
+   case of the CNC Controller or other product you make using this source.
+  
+   You should have received a copy of the CERN-OHL-S v2 license with this source.
+   If not, see <https://ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2>.
+   
+   Contact for information regarding this program and its license
+   can be sent through gSender@sienci.com or mailed to the main office
+   of Sienci Labs Inc. in Waterloo, Ontario, Canada.
 
   M356 -  On = 1, Off = 2, RGB white LED inspection light in RGB Plugin
 */

--- a/rgb.h
+++ b/rgb.h
@@ -19,6 +19,29 @@
   You should have received a copy of the GNU General Public License
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
+  Copyright (c) 2023 Sienci Labs
+
+  This file is part of the SuperLongBoard family of products.
+  
+   This source describes Open Hardware and is licensed under the "CERN-OHL-S v2"
+
+   You may redistribute and modify this source and make products using
+   it under the terms of the CERN-OHL-S v2 (https://ohwr.org/cern_ohl_s_v2.t). 
+   This source is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
+   INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A 
+   PARTICULAR PURPOSE. Please see the CERN-OHL-S v2 for applicable conditions.
+   
+   As per CERN-OHL-S v2 section 4, should You produce hardware based on this 
+   source, You must maintain the Source Location clearly visible on the external
+   case of the CNC Controller or other product you make using this source.
+  
+   You should have received a copy of the CERN-OHL-S v2 license with this source.
+   If not, see <https://ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2>.
+   
+   Contact for information regarding this program and its license
+   can be sent through gSender@sienci.com or mailed to the main office
+   of Sienci Labs Inc. in Waterloo, Ontario, Canada.
+
 */
 
 #pragma once

--- a/ws2812.c
+++ b/ws2812.c
@@ -1,4 +1,32 @@
 /*
+
+   Copyright (C) Sienci Labs Inc.
+  
+   This file is part of the SuperLongBoard family of products.
+  
+   This source describes Open Hardware and is licensed under the "CERN-OHL-S v2"
+
+   You may redistribute and modify this source and make products using
+   it under the terms of the CERN-OHL-S v2 (https://ohwr.org/cern_ohl_s_v2.t). 
+   This source is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
+   INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A 
+   PARTICULAR PURPOSE. Please see the CERN-OHL-S v2 for applicable conditions.
+   
+   As per CERN-OHL-S v2 section 4, should You produce hardware based on this 
+   source, You must maintain the Source Location clearly visible on the external
+   case of the CNC Controller or other product you make using this source.
+  
+   You should have received a copy of the CERN-OHL-S v2 license with this source.
+   If not, see <https://ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2>.
+   
+   Contact for information regarding this program and its license
+   can be sent through gSender@sienci.com or mailed to the main office
+   of Sienci Labs Inc. in Waterloo, Ontario, Canada.
+
+*/
+
+
+/*
 #include "WS2812.h"
 #include "PixelArray.h"
 

--- a/ws2812.h
+++ b/ws2812.h
@@ -1,3 +1,30 @@
+/*
+
+   Copyright (C) Sienci Labs Inc.
+  
+   This file is part of the SuperLongBoard family of products.
+  
+   This source describes Open Hardware and is licensed under the "CERN-OHL-S v2"
+
+   You may redistribute and modify this source and make products using
+   it under the terms of the CERN-OHL-S v2 (https://ohwr.org/cern_ohl_s_v2.t). 
+   This source is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
+   INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A 
+   PARTICULAR PURPOSE. Please see the CERN-OHL-S v2 for applicable conditions.
+   
+   As per CERN-OHL-S v2 section 4, should You produce hardware based on this 
+   source, You must maintain the Source Location clearly visible on the external
+   case of the CNC Controller or other product you make using this source.
+  
+   You should have received a copy of the CERN-OHL-S v2 license with this source.
+   If not, see <https://ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2>.
+   
+   Contact for information regarding this program and its license
+   can be sent through gSender@sienci.com or mailed to the main office
+   of Sienci Labs Inc. in Waterloo, Ontario, Canada.
+
+*/
+
 #ifndef WS2812_H
 #define WS2812_H
 


### PR DESCRIPTION
This code has been created within the context of Open Hardware and is licensed under the "CERN-OHL-S v2". Please read more about this in the LICENSE file. You could redistribute and modify this source and make products using it under the terms of the CERN-OHL-S v2. This means stuff like licensing your changes reciprocally, giving attribution to us, and releasing hardware that this code runs on as CERN-OHL-S v2 too. Note that this LICENSE applies on all coding work done in prior commits to-date, and is now being released in good faith that no action will be taken to pursue past work in order to duplicate the work we've put in without having to abide by the License that's now being applied at its first public release.